### PR TITLE
Update video.dart

### DIFF
--- a/lib/src/video.dart
+++ b/lib/src/video.dart
@@ -406,7 +406,8 @@ class _AwsomeVideoPlayerState extends State<AwsomeVideoPlayer>
     final netRegx = new RegExp(r'^(http|https):\/\/([\w.]+\/?)\S*');
     final fileRegx = new RegExp(r'^(file):\/\/([\w.]+\/?)\S*');
     final isNetwork = netRegx.hasMatch(widget.dataSource);
-    final isFile = fileRegx.hasMatch(widget.dataSource);
+    // final isFile = fileRegx.hasMatch(widget.dataSource); 2020-9-30 04:37:23
+    final isFile = widget.dataSource is File;
     if (isNetwork) {
       return VideoPlayerController.network(widget.dataSource);
     } else if (isFile) {


### PR DESCRIPTION
无法播放本地文件的bug
外层入参是文件路或地址，但是打开文件的时候，controller的入参是一个文件类型